### PR TITLE
Fix 'TypeError' while use image-resizer

### DIFF
--- a/src/Cropper/Cropper.page.tsx
+++ b/src/Cropper/Cropper.page.tsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { Animated, PanResponder, Platform, PanResponderInstance, PanResponderGestureState, ImageCropData } from 'react-native';
-import { createResizedImage } from '@bam.tech/react-native-image-resizer';
+import ImageResizer from '@bam.tech/react-native-image-resizer';
 // @ts-ignore - react-native-image-rotate does not have typescript support
 import ImageRotate from '@wili/react-native-image-rotate';
 import ImageEditor from '@react-native-community/image-editor';
@@ -697,7 +697,7 @@ class CropperPage extends Component<CropperPageProps, State> {
       resizeMode: 'stretch',
     } as ImageCropData;
     // we need to use this function because otherwise the crop may not work properly (see https://github.com/callstack/react-native-image-editor/issues/54)
-    createResizedImage(this.props.imageUri, imageWidth, imageHeight, 'JPEG', 100, Platform.OS === 'ios' ? 0 : this.state.rotation, undefined, false, {
+    ImageResizer.createResizedImage(this.props.imageUri, imageWidth, imageHeight, 'JPEG', 100, Platform.OS === 'ios' ? 0 : this.state.rotation, undefined, false, {
       mode: 'cover',
       onlyScaleDown: true,
     })


### PR DESCRIPTION
Babel@6 doesn't export default module.exports any more 
https://www.npmjs.com/package/babel-plugin-add-module-exports 
https://github.com/babel/babel/issues/2212